### PR TITLE
Kubernetes example

### DIFF
--- a/examples/kubernetes/.env
+++ b/examples/kubernetes/.env
@@ -1,0 +1,2 @@
+# Obtain this value from your shell's settings page, e.g. https://app.cased.com/shell/programs/shell_EXAMPLE/settings
+#CASED_SHELL_SECRET=shell_EXAMPLE

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,49 @@
+# Running Cased Shell on Kubernetes
+
+> If you have any questions, please email us at support@cased.com!
+### Prerequisites
+
+- A Kubernetes cluster that can either provide public access to a service (via a Service Load Balancer or Ingress Controller) or private access to a Service with self-managed TLS.
+- Access to the settings tab of Cased Shell instance created using a hostname that can access the Kubernetes cluster as mentioned above (e.g. https://app.cased.com/shell/programs/shell_EXAMPLE/settings), with Certificate Authentication enabled.
+- Local `kubectl` access to the cluster.
+
+## Summary
+
+The example in this directory deploys Cased Shell and an internally-accessible SSH server to your Kubernetes cluster. The container running the SSH server is granted admin access to the Kubernetes cluster, and is configured to allow access from any member of your SSO organization.
+## Deploying
+
+### Create a namespace
+
+```
+kubectl create ns shell
+```
+
+### Update configuration
+
+```
+vi .env
+```
+
+Update the Kustomize file, paying special attention to the ingress strategy your cluster uses. You will need to either edit `ingresses/cased-shell.yaml` or [patch](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#customizing) the included Service to change its type to LoadBalancer to allow HTTPS traffic to reach Cased Shell using `$CASED_SHELL_HOSTNAME`.
+
+```
+vi ingresses/cased-shell.yaml
+vi kustomization.yaml
+```
+
+### Preview configuration
+
+```
+kubectl kustomize examples/kubernetes | less
+```
+
+### Apply configuration
+
+
+```
+kubectl -n shell apply -k examples/kubernetes
+```
+
+### Visit your shell
+
+Next, visit your shell instance at https://$CASED_SHELL_HOSTNAME. After logging in, click the `kubectl` prompt to run interactive commands using `kubectl`, or use the `event log` link to see a stream of all Kubernetes events.

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -12,6 +12,15 @@
 The example in this directory deploys Cased Shell and an internally-accessible SSH server to your Kubernetes cluster. The container running the SSH server is granted admin access to the Kubernetes cluster, and is configured to allow access from any member of your SSO organization.
 ## Deploying
 
+### Clone this repo
+
+```
+git clone https://github.com/cased/try-shell
+cd try-shell
+# TODO remove before merge
+git checkout kustomize
+```
+
 ### Create a namespace
 
 ```
@@ -27,8 +36,8 @@ vi .env
 Update the Kustomize file, paying special attention to the ingress strategy your cluster uses. You will need to either edit `ingresses/cased-shell.yaml` or [patch](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/#customizing) the included Service to change its type to LoadBalancer to allow HTTPS traffic to reach Cased Shell using `$CASED_SHELL_HOSTNAME`.
 
 ```
-vi ingresses/cased-shell.yaml
-vi kustomization.yaml
+vi examples/kubernetes/ingresses/cased-shell.yaml
+vi examples/kubernetes/kustomization.yaml
 ```
 
 ### Preview configuration

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -17,8 +17,6 @@ The example in this directory deploys Cased Shell and an internally-accessible S
 ```
 git clone https://github.com/cased/try-shell
 cd try-shell
-# TODO remove before merge
-git checkout kustomize
 ```
 
 ### Create a namespace

--- a/examples/kubernetes/clusterrolebindings/kubectl-sshd.yaml
+++ b/examples/kubernetes/clusterrolebindings/kubectl-sshd.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  name: kubectl-sshd
+  namespace: ""
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: kubectl-sshd

--- a/examples/kubernetes/ingresses/cased-shell.yaml
+++ b/examples/kubernetes/ingresses/cased-shell.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/proxy-ssl-server-name: "on"
+  name: cased-shell
+spec:
+  rules:
+  - host: shell.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: cased-shell
+            port:
+              number: 443
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - shell.example.com
+    secretName: cased-shell-tls

--- a/examples/kubernetes/jump.yaml
+++ b/examples/kubernetes/jump.yaml
@@ -15,7 +15,7 @@ queries:
       featured: true
       username: kubectl
       hostname: kubectl-sshd
-      jumpCommand: kubectl -n shell exec -it deploy/shell -- /bin/bash
+      jumpCommand: kubectl -n shell exec -it deploy/cased-shell -- /bin/bash
   - provider: static
     prompt:
       name: event log

--- a/examples/kubernetes/jump.yaml
+++ b/examples/kubernetes/jump.yaml
@@ -1,0 +1,26 @@
+queries:
+  - provider: static
+    prompt:
+      name: kubectl
+      description: a shell with kubectl and access to the cluster
+      featured: true
+      hostname: kubectl-sshd
+      username: kubectl
+      labels:
+        app: kubectl
+  - provider: static
+    prompt:
+      name: shell
+      description: a shell on the shell deployment
+      featured: true
+      username: kubectl
+      hostname: kubectl-sshd
+      jumpCommand: kubectl -n shell exec -it deploy/shell -- /bin/bash
+  - provider: static
+    prompt:
+      name: event log
+      description: kubernetes events
+      featured: true
+      username: kubectl
+      hostname: kubectl-sshd
+      jumpCommand: kubectl get events --all-namespaces -w

--- a/examples/kubernetes/kustomization.yaml
+++ b/examples/kubernetes/kustomization.yaml
@@ -2,11 +2,9 @@ namespace: shell
 
 resources:
 # A Cased Shell Deployment, Service, and ServiceAccount
-# TODO remove ref before merge
-- https://github.com/cased/try-shell/kustomize/bases/cased-shell?ref=kustomize
+- https://github.com/cased/try-shell/kustomize/bases/cased-shell
 # A SSHD Deployment, Service, and ServiceAccount
-# TODO remove ref before merge
-- https://github.com/cased/try-shell/kustomize/bases/kubectl-sshd?ref=kustomize
+- https://github.com/cased/try-shell/kustomize/bases/kubectl-sshd
 # An Ingress object facilitating access to the cased-shell Service.
 - ingresses/cased-shell.yaml
 # A ClusterRoleBinding granting the the kubectl-sshd ServiceAccount admin access to the cluster.

--- a/examples/kubernetes/kustomization.yaml
+++ b/examples/kubernetes/kustomization.yaml
@@ -2,8 +2,10 @@ namespace: shell
 
 resources:
 # A Cased Shell Deployment, Service, and ServiceAccount
+# TODO remove ref before merge
 - https://github.com/cased/try-shell/kustomize/bases/cased-shell?ref=kustomize
 # A SSHD Deployment, Service, and ServiceAccount
+# TODO remove ref before merge
 - https://github.com/cased/try-shell/kustomize/bases/kubectl-sshd?ref=kustomize
 # An Ingress object facilitating access to the cased-shell Service.
 - ingresses/cased-shell.yaml

--- a/examples/kubernetes/kustomization.yaml
+++ b/examples/kubernetes/kustomization.yaml
@@ -1,0 +1,36 @@
+namespace: shell
+
+resources:
+# A Cased Shell Deployment, Service, and ServiceAccount
+- https://github.com/cased/try-shell/kustomize/bases/cased-shell?ref=kustomize
+# A SSHD Deployment, Service, and ServiceAccount
+- https://github.com/cased/try-shell/kustomize/bases/kubectl-sshd?ref=kustomize
+# An Ingress object facilitating access to the cased-shell Service.
+- ingresses/cased-shell.yaml
+# A ClusterRoleBinding granting the the kubectl-sshd ServiceAccount admin access to the cluster.
+- clusterrolebindings/kubectl-sshd.yaml
+
+secretGenerator:
+- name: cased-shell
+  envs:
+  - .env
+
+configMapGenerator:
+- name: jump
+  files:
+  - ./jump.yaml
+- name: cased-shell
+  literals:
+  # !!! IMPORTANT !!!
+  # Set to the hostname you'll be using to access this deployment of Cased Shell
+  - CASED_SHELL_HOSTNAME=shell.example.com
+  # !!! IMPORTANT !!!
+  # Set to internal if your ingress provider handles TLS. If using a Service Load Balancer, set to 'auto' to automatically obtain SSL certs. Set to 'off' if your load balancer may only communicate with backends over HTTP
+  - CASED_SHELL_TLS=internal
+  # https://docs.cased.com/docs/environment-variables
+- name: kubectl-sshd
+  literals:
+  # !!! IMPORTANT !!!
+  # Set to the authorized_keys entry provided on your Cased Shell settings page, e.g. # Obtain this value from your shell's settings page, e.g. https://app.cased.com/shell/programs/shell_EXAMPLE/settings
+  - PUBLIC_KEY="cert-authority,principals="noreply+org_EXAMPLE@cased.com" ecdsa-sha2-nistp256 AAAAEXAMPLE="
+  - KUBECTL_VERSION=v1.20.12

--- a/kustomize/bases/cased-shell/README.md
+++ b/kustomize/bases/cased-shell/README.md
@@ -1,0 +1,5 @@
+Creates a cased-shell Deployment, Service, and ServiceAccount.
+
+## Configuration
+
+Environment variable configuration is loaded from the `cased-shell` Secret and ConfigMap. See https://docs.cased.com/docs/environment-variables for expected values.

--- a/kustomize/bases/cased-shell/deployments/cased-shell.yaml
+++ b/kustomize/bases/cased-shell/deployments/cased-shell.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: cased-shell
+  name: cased-shell
+spec:
+  selector:
+    matchLabels:
+      app: cased-shell
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: 'cased-shell'
+      labels:
+        app: cased-shell
+    spec:
+      enableServiceLinks: false
+      serviceAccountName: cased-shell
+      containers:
+        - name: cased-shell
+          image: ghcr.io/cased/shell:unstable
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: config
+              mountPath: "/config"
+              readOnly: true
+          ports:
+            - name: https
+              containerPort: 443
+          envFrom:
+            - secretRef:
+                name: cased-shell
+            - configMapRef:
+                name: cased-shell
+          env:
+            - name: CASED_SHELL_LOG_LEVEL
+              value: info
+            - name: CASED_SHELL_HOST_FILE
+              value: /config/jump.json
+          readinessProbe:
+            httpGet:
+              path: /_health
+              port: 80
+        - name: jump
+          image: ghcr.io/cased/jump:latest
+          imagePullPolicy: Always
+          command: ["/bin/app", "/jump/jump.yaml", "/config/jump.json"]
+          volumeMounts:
+            - name: config
+              mountPath: "/config"
+            - name: jump
+              mountPath: "/jump"
+      volumes:
+      - name: config
+        emptyDir: {}
+      - name: jump
+        configMap:
+          name: jump

--- a/kustomize/bases/cased-shell/deployments/cased-shell.yaml
+++ b/kustomize/bases/cased-shell/deployments/cased-shell.yaml
@@ -29,6 +29,8 @@ spec:
           ports:
             - name: https
               containerPort: 443
+            - name: http
+              containerPort: 8888
           envFrom:
             - secretRef:
                 name: cased-shell

--- a/kustomize/bases/cased-shell/kustomization.yaml
+++ b/kustomize/bases/cased-shell/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deployments/cased-shell.yaml
+- serviceaccounts/cased-shell.yaml
+- services/cased-shell.yaml

--- a/kustomize/bases/cased-shell/serviceaccounts/cased-shell.yaml
+++ b/kustomize/bases/cased-shell/serviceaccounts/cased-shell.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cased-shell

--- a/kustomize/bases/cased-shell/services/cased-shell.yaml
+++ b/kustomize/bases/cased-shell/services/cased-shell.yaml
@@ -7,5 +7,9 @@ spec:
   - port: 443
     targetPort: https
     name: https
+  # Optional, disabled by default.
+  # - port: 80
+  #   targetPort: http
+  #   name: http
   selector:
     app: cased-shell

--- a/kustomize/bases/cased-shell/services/cased-shell.yaml
+++ b/kustomize/bases/cased-shell/services/cased-shell.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cased-shell
+spec:
+  ports:
+  - port: 443
+    targetPort: https
+    name: https
+  selector:
+    app: cased-shell

--- a/kustomize/bases/kubectl-sshd/README.md
+++ b/kustomize/bases/kubectl-sshd/README.md
@@ -1,0 +1,5 @@
+A container with an SSH server and a kubectl client, designed to be used as a 'jump host' for kubectl actions alongside Cased Shell. 
+
+# Configuration
+
+Expects a `kubectl-sshd` configmap with `KUBECTL_VERSION` and `PUBLIC_KEY` values.

--- a/kustomize/bases/kubectl-sshd/deployments/kubectl-sshd.yaml
+++ b/kustomize/bases/kubectl-sshd/deployments/kubectl-sshd.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kubectl-sshd
+  name: kubectl-sshd
+spec:
+  selector:
+    matchLabels:
+      app: kubectl-sshd
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: 'kubectl-sshd'
+      labels:
+        app: kubectl-sshd
+    spec:
+      serviceAccountName: kubectl-sshd
+      containers:
+        - name: kubectl-sshd
+          image: linuxserver/openssh-server
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "Welcome to the Cased Shell kubectl container. Grant the kubectl-sshd serviceaccount access to anything you'd like to access." > /etc/motd
+
+              curl -sL https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
+              chmod +x /usr/local/bin/kubectl
+
+              mkdir -p /config/custom-cont-init.d/
+              cat << EOF > /config/custom-cont-init.d/88-cased
+              #!/bin/sh
+              sed -i 's@#PermitUserEnvironment no@PermitUserEnvironment yes@' /etc/ssh/sshd_config
+              touch /done
+              EOF
+              chmod a+x /config/custom-cont-init.d/88-cased
+
+              cat > /setup.sh <<EOF
+              #!/bin/sh
+              mkdir -p /home/$USER_NAME
+              cp -r /config/.ssh /home/$USER_NAME/
+              env | grep KUBERNETES > /home/$USER_NAME/.ssh/environment
+              chown -R $USER_NAME:$USER_NAME /home/$USER_NAME
+              usermod -d /home/$USER_NAME $USER_NAME
+              tail -F /does-not-exist 2>/dev/null
+              EOF
+              chmod +x /setup.sh
+              /init /setup.sh
+          env:
+            - name: USER_NAME
+              value: kubectl
+            - name: PASSWORD_ACCESS
+              value: "false"
+            - name: SUDO_ACCESS
+              value: "false"
+          envFrom:
+            - configMapRef:
+                name: kubectl-sshd
+          ports:
+            - name: sshd
+              containerPort: 2222

--- a/kustomize/bases/kubectl-sshd/kustomization.yaml
+++ b/kustomize/bases/kubectl-sshd/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- deployments/kubectl-sshd.yaml
+- serviceaccounts/kubectl-sshd.yaml
+- services/kubectl-sshd.yaml

--- a/kustomize/bases/kubectl-sshd/serviceaccounts/kubectl-sshd.yaml
+++ b/kustomize/bases/kubectl-sshd/serviceaccounts/kubectl-sshd.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-sshd

--- a/kustomize/bases/kubectl-sshd/services/kubectl-sshd.yaml
+++ b/kustomize/bases/kubectl-sshd/services/kubectl-sshd.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubectl-sshd
+spec:
+  ports:
+  - port: 22
+    targetPort: sshd
+    name: sshd
+  selector:
+    app: kubectl-sshd


### PR DESCRIPTION
https://github.com/cased/try-shell/blob/kustomize/examples/kubernetes/README.md contains a walkthrough that potential customers can use to deploy Cased Shell to a Kubernetes cluster after brief configuration. The resulting deployment contains an example of an interactive prompt to run various `kubectl` commands, an example of a streaming command (in this case a stream of events from the Kubernetes cluster), and an example of exec-ing a bash shell inside a container.

<img width="645" alt="image" src="https://user-images.githubusercontent.com/47/140407843-e21b850b-c5e1-423f-9aa6-8c08b16a434b.png">

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/47/140407819-088f1167-6701-459c-9aa3-2de0585e0d3e.png">

The contents of `kustomize/bases` will likely be relocated to another repository and be released with a cadence mirroring that of `ghcr.io/cased/shell`, pending feedback.

A direct example is included for customers using an nginix-ingress ingress pattern; one could also be included for an AWS-based cluster but we need to stand one up first to confirm it.